### PR TITLE
ipv6 ping fix, self-hosted runner, ipv6 and on-device tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    # if you fork this repo, you should change this to ubuntu-latest
+    # you should also disable ipv6 tests, and the android tests
+    # (the self-hosted tests have ipv6 on the host and a phone attached to the runner)
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK
@@ -25,8 +28,8 @@ jobs:
       - name: Build and Publish the Android and Linux Libraries to the local Maven repository
         run: ./gradlew :icmp-android:publishToMavenLocal :icmp-linux:publishToMavenLocal
       - name: Build with Gradle
-        run: ./gradlew assemble # we don't use build because that will run the tests, we want that separate
+        run: ./gradlew assemble          # we don't use build because that will run the tests, we want that separate
       - name: JVM Unit tests
         run: ./gradlew check
-#      - name: Android Instrumented tests # disabled until we can setup a self hosted runner
-#        run: ./gradlew connectedCheck
+      - name: Android Instrumented tests # disable if you don't have a phone attached to the runner
+        run: ./gradlew connectedCheck

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ JVM implementations.
 implementation("com.jasonernst.icmp:icmp-android")
 ```
 
+Using the Library:
+```kotlin
+import com.jasonernst.icmp.ICMPAndroid 
+import java.net.InetAddress
+
+// this will ping google.com with a dns resolution timeout of 500ms and an ICMP timeout of 1000ms
+ICMPAndroid.ping("google.com", 500, 1000)
+
+// this will ping the local host with a timeout of 1000ms. Note that the InetAddress object is used
+// here, and that when we do this, there is no DNS request made because we already have the IP address
+ICMPAndroid.ping(InetAddress.getLocalHost(), 1000)
+```
+
 ### Linux JVM
 Note the the Linux JVM implementation uses a .so file that is built using cmake. For unit tests,
 the .so file is added to the lib path for the test task. For the actual library, the .so file is
@@ -20,6 +33,19 @@ the .so is produced as a separate artifact and then included in the library as a
 location of the .so file is added to the java.library.path. This is a future improvement.
 ```kotlin
 implementation("com.jasonernst.icmp:icmp-linux")
+```
+
+Using the library:
+```kotlin
+import java.net.InetAddress
+import com.jasonernst.icmp.ICMPLinux
+
+// this will ping google.com with a dns resolution timeout of 500ms and an ICMP timeout of 1000ms
+ICMPLinux.ping("google.com", 500, 1000)
+
+// this will ping the local host with a timeout of 1000ms. Note that the InetAddress object is used
+// here, and that when we do this, there is no DNS request made because we already have the IP address
+ICMPLinux.ping(InetAddress.getLocalHost(), 1000)
 ```
 
 ## Building locally:

--- a/icmp-linux/src/test/kotlin/com/jasonernst/icmp_linux/JVMPingTest.kt
+++ b/icmp-linux/src/test/kotlin/com/jasonernst/icmp_linux/JVMPingTest.kt
@@ -1,6 +1,5 @@
 package com.jasonernst.icmp_linux
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 /**
@@ -15,7 +14,6 @@ class JVMPingTest {
         icmp.ping("localhost")
     }
 
-    @Disabled("IPv6 not supported on GH actions hosted runners")
     @Test
     fun pingIpv6Localhost() {
         icmp.ping("::1")

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:base"
   ],
+  "ignoreDeps": ["icmp_common", "icmp_android", "icmp_linux"],
   "packageRules": [
     {
       "description": "Automerge non-major updates",


### PR DESCRIPTION
- Turns on the self-hosted runner for android on device tests (instrumented tests)
- Uses the self-hosted runner for ipv6 tests
- Fixes the icmpv6 ping test which was broken